### PR TITLE
Use standard streams

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -74,7 +74,10 @@ mod tests {
 
         assert_eq!(config.db_url, "foodb");
         assert_eq!(config.db_channel, "foochan");
-        assert_eq!(config.exec_command, "sh test.sh");
+        assert_eq!(
+            config.command_vector,
+            vec![OsString::from("sh"), OsString::from("test.sh")]
+        );
         assert_eq!(config.max_threads, 5);
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -1,46 +1,56 @@
 extern crate clap;
-use thread_pool::{ThreadPool};
-use self::clap::{ArgMatches};
+
+use std::ffi::OsString;
+use thread_pool;
+
 
 #[derive(Debug, Clone)]
-pub struct DispatcherConfig <'a> {
+pub struct Config<'a> {
     pub db_url: &'a str,
     pub db_channel: &'a str,
-    pub exec_command: &'a str,
     pub max_threads: usize,
+    pub command_vector: Vec<OsString>,
 }
 
-impl <'a>DispatcherConfig<'a> {
-    pub fn from_matches(matches: &'a ArgMatches<'a>) -> DispatcherConfig {
+impl<'a> Config<'a> {
+    pub fn from_matches(matches: &'a clap::ArgMatches<'a>) -> Config {
         let max_threads = match matches.value_of("workers") {
             Some(v) => v.parse::<usize>().unwrap_or(4),
-            _ => 4
+            _ => 4,
         };
 
-        DispatcherConfig {
+        let command_vector: Vec<OsString> = matches
+            .value_of("exec")
+            .unwrap()
+            .split_whitespace()
+            .map(|s| OsString::from(s))
+            .collect();
+
+        Config {
             db_url: matches.value_of("db-uri").unwrap(),
             db_channel: matches.value_of("channel").unwrap(),
-            exec_command: matches.value_of("exec").unwrap(),
-            max_threads: max_threads
+            max_threads: max_threads,
+            command_vector: command_vector,
         }
     }
 }
 
 #[derive(Debug)]
-pub struct Dispatcher<'a> {
-    pub config: &'a DispatcherConfig<'a>,
-    pub pool: ThreadPool
+pub struct Dispatcher {
+    pub pool: thread_pool::ThreadPool,
 }
 
-impl <'a>Dispatcher<'a> {
-    pub fn from_config(config: &'a DispatcherConfig<'a>) -> Dispatcher {
+impl Dispatcher {
+    pub fn from_config(config: &Config) -> Dispatcher {
         Dispatcher {
-            config: config,
-            pool: ThreadPool::new(config.max_threads)
+            pool: thread_pool::ThreadPool::new(config.max_threads, config.command_vector.clone()),
         }
     }
-}
 
+    pub fn execute_command(&self, payload: String) {
+        self.pool.execute(payload)
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -49,13 +59,18 @@ mod tests {
 
     #[test]
     fn dispatcher_config_from_matches_test() {
-        let matches = cli::create_cli_app()
-            .get_matches_from(vec![
-                              "pg-dispatch", "--db-uri", "foodb",
-                              "--channel", "foochan",
-                              "--exec", "sh test.sh",
-                              "--workers", "5"]);
-        let config = DispatcherConfig::from_matches(&matches);
+        let matches = cli::create_cli_app().get_matches_from(vec![
+            "pg-dispatch",
+            "--db-uri",
+            "foodb",
+            "--channel",
+            "foochan",
+            "--exec",
+            "sh test.sh",
+            "--workers",
+            "5",
+        ]);
+        let config = Config::from_matches(&matches);
 
         assert_eq!(config.db_url, "foodb");
         assert_eq!(config.db_channel, "foochan");
@@ -65,13 +80,18 @@ mod tests {
 
     #[test]
     fn dispatcher_from_config() {
-        let matches = cli::create_cli_app()
-            .get_matches_from(vec![
-                              "pg-dispatch", "--db-uri", "foodb",
-                              "--channel", "foochan",
-                              "--exec", "sh test.sh",
-                              "--workers", "5"]);
-        let config = DispatcherConfig::from_matches(&matches);
+        let matches = cli::create_cli_app().get_matches_from(vec![
+            "pg-dispatch",
+            "--db-uri",
+            "foodb",
+            "--channel",
+            "foochan",
+            "--exec",
+            "sh test.sh",
+            "--workers",
+            "5",
+        ]);
+        let config = Config::from_matches(&matches);
 
         let _disptacher = Dispatcher::from_config(&config);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,17 @@ fn main() {
     // parse arguments and build dispatcher
     let cli_matches = create_cli_app().get_matches();
     let config = DispatcherConfig::from_matches(&cli_matches);
+
+    // connect to the database
+    let conn = Connection::connect(config.db_url, TlsMode::None).unwrap();
+    let _listen_execute = conn.execute(&format!("LISTEN {}", config.db_channel), &[]);
+    let notifications = conn.notifications();
+    let mut iter = notifications.blocking_iter();
+
+    // instantiate dispatcher
     let dispatcher = Dispatcher::from_config(&config);
 
-    // create command vector reference
+    // use a command vector reference
     let command_vector: Arc<Vec<OsString>> = Arc::new(
         config
             .exec_command

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,19 +5,17 @@ mod cli;
 mod dispatcher;
 mod thread_pool;
 
-use postgres::{Connection, TlsMode};
-use dispatcher::{Dispatcher, DispatcherConfig};
-use fallible_iterator::FallibleIterator;
 use cli::create_cli_app;
-use std::process::{Command, exit};
-use std::ffi::OsString;
-use std::sync::Arc;
+use dispatcher::{Dispatcher, Config};
+use fallible_iterator::FallibleIterator;
+use postgres::{Connection, TlsMode};
+use std::process::exit;
 
 
 fn main() {
     // parse arguments and build dispatcher
     let cli_matches = create_cli_app().get_matches();
-    let config = DispatcherConfig::from_matches(&cli_matches);
+    let config = Config::from_matches(&cli_matches);
 
     // connect to the database
     let conn = match Connection::connect(config.db_url, TlsMode::None) {
@@ -27,51 +25,27 @@ fn main() {
             exit(1);
         }
     };
-    if let Err(error) = conn.execute(&format!("LISTEN {}", config.db_channel), &[]) {
+    if let Err(_) = conn.execute(&format!("LISTEN {}", config.db_channel), &[]) {
         eprintln!("Failed to execute LISTEN command in database.");
         exit(1)
     }
+
+    println!(
+        "[pg-dispatch] Listening to \"{}\" channel.",
+        config.db_channel
+    );
+
+    // make an iterator over notifications
     let notifications = conn.notifications();
     let mut iter = notifications.blocking_iter();
 
     // instantiate dispatcher
     let dispatcher = Dispatcher::from_config(&config);
 
-    // use a shared reference for the command vector
-    let command_vector: Arc<Vec<OsString>> = Arc::new(
-        config
-            .exec_command
-            .split_whitespace()
-            .map(|s| OsString::from(s))
-            .collect(),
-    );
-
     // main loop
     loop {
         match iter.next() {
-            Ok(Some(notification)) => {
-
-                let command_vector = Arc::clone(&command_vector);
-
-                dispatcher.pool.execute(move || {
-                    let output =
-                        Command::new(&command_vector[0])
-                            .args(&command_vector[1..])
-                            .env("PG_DISPATCH_PAYLOAD", notification.payload)
-                            .output()
-                            .unwrap_or_else(|e| panic!("failed to execute process: {}\n", e));
-
-                    if output.status.success() {
-                        let s = String::from_utf8_lossy(&output.stdout);
-
-                        print!("sh stdout was: {}", s);
-                    } else {
-                        let s = String::from_utf8_lossy(&output.stderr);
-
-                        print!("rustc failed and stderr was:\n{}\n", s);
-                    }
-                });
-            }
+            Ok(Some(notification)) => dispatcher.execute_command(notification.payload),
             _ => {}
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
     // instantiate dispatcher
     let dispatcher = Dispatcher::from_config(&config);
 
-    // use a command vector reference
+    // use a shared reference for the command vector
     let command_vector: Arc<Vec<OsString>> = Arc::new(
         config
             .exec_command
@@ -42,7 +42,6 @@ fn main() {
             .map(|s| OsString::from(s))
             .collect(),
     );
-
 
     loop {
         match iter.next() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,15 +24,15 @@ fn main() {
     loop {
         match iter.next() {
             Ok(Some(notification)) => {
-                let cmd_handler = config.exec_command.to_string().clone();
-                let payload = notification.payload.clone();
+                let cmd_handler = config.exec_command.to_string();
+
                 dispatcher.pool.execute(move || {
                     let split = cmd_handler.split_whitespace();
                     let cmd_vector = split.collect::<Vec<&str>>();
                     let output =
                         Command::new(cmd_vector[0])
                             .args(&cmd_vector[1..cmd_vector.len()])
-                            .env("PG_DISPATCH_PAYLOAD", payload)
+                            .env("PG_DISPATCH_PAYLOAD", notification.payload)
                             .output()
                             .unwrap_or_else(|e| panic!("failed to execute process: {}\n", e));
 


### PR DESCRIPTION
1. Implemented echoing of `stdout` and `stderr` to their proper streams at main thread.

2. Also removed one "thread-layer" by making workers spawn sub-process directly, instead of passing closures that spawned sub-process to workers:
  - Before: `main thread > worker > closure > sub-process`
  - After: `main thread > worker > sub-process`

3. Since closures are no longer sent through channels, the `FnBox` trait was removed too.