### PR TITLE
Send notification payload through stdin instead of an environment variable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "pg-dispatcher"
 version = "0.1.0"
-authors = ["Antônio Roberto <forevertonny@gmail.com>"]
+authors = ["Antônio Roberto <forevertonny@gmail.com>", "Tiago Guimarães <tilacog@gmail.com>"]
+
 
 [dependencies]
 clap = "~2.19.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # pg-dispatch
 
-Abstract listener for PostgreSQL, that listens to a single database channel and executes a
+Abstract listener for PostgreSQL that listens to a single database channel and executes a
 given command when a notification arrives. The notification payload, if any, is sent
 though the executed command's standard input.
 
@@ -75,8 +75,8 @@ You can also use commands with arguments, just pass them inside the same string:
 ```sh
 $ ./target/release/pg-disptacher                         \
       --db-uri='postgres://postgres@localhost/postgres'  \
-      --channel="test_channel"							 \
-	  --exec="sh some-script.sh"                         \
+      --channel="test_channel"                           \
+      --exec="sh some-script.sh"                         \
       --workers=100
 ```
 
@@ -84,13 +84,13 @@ Where `some-script.sh` could be like:
 
 ```sh
 #!/bin/sh
-
 PAYLOAD=$(cat) # read from stdin
 echo "The payload was: $PAYLOAD!"
 ```
 
 Output *(after notification was issued)*:
 ```
+[pg-dispatch] Listening to channel: "test_channel".
 [worker-1] Got payload: hello from postgres.
 [worker-1] Command succeded with status code 0.
 [sh-1] The payload was: hello from postgres!

--- a/README.md
+++ b/README.md
@@ -1,33 +1,97 @@
 ### under development
 
-# pg-dispatcher
-Abstract listener for PostgreSQL, that listen ah single channel and dispatch the messages via any command execution of database.
+# pg-dispatch
 
-## install
+Abstract listener for PostgreSQL, that listens to a single database channel and executes a
+given command when a notification arrives. The notification payload, if any, is sent
+though the executed command's standard input.
 
-`git clone git@github.com:common-group/pg-dispatcher.git`
+## Installation
 
-`cd pg-dispatcher`
+1. `$ git clone git@github.com:common-group/pg-dispatcher.git`
+2. `$ cd pg-dispatcher`
+3. `$ cargo build --release`
 
-`cargo build --release`
+## Usage
 
-## usage (example)
-
-create a file to process the payload message:
-
-`echo 'echo $PG_DISPTACH_PAYLOAD' > test.sh`
-
-running compiled bin:
 ```
-./target/release/pg-disptacher --db-uri='postgres://postgres@localhost/postgres' \ 
-  --channel="test_channel" \
-  --exec="sh ./test.sh" \
-  --workers=100
+$ pg-dispatcher --help
+
+pg-dispatcher 1.0
+Listens a PostgreSQL Notification and send through a command execution
+
+USAGE:
+    pg-dispatcher [OPTIONS] --db-uri <db-uri> --channel <channel> --exec <exec>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+        --channel <channel>    channel to LISTEN
+        --db-uri <db-uri>      database connection string postgres://user:pass@host:port/dbname
+        --exec <exec>          command to execute when receive a notification
+        --workers <workers>    max num of workers (threads) to spawn. defaults is 4
 ```
 
-connect at you database and execute:
-```
-  select pg_notify('test_channel', json_build_object('id', '1')::text);
+### Examples
+
+#### Dispatching a command without arguments
+
+The example below will listen to a PostgreSQL database channel named `test_channel` and
+execute the command `cat` whenever a new notification arrives, using `100` threads at
+maximum.
+
+*(Note that the `cat` command reads from standard input when no file is specified)*
+
+```sh
+$ ./target/release/pg-disptacher                         \
+      --db-uri='postgres://postgres@localhost/postgres'  \
+      --channel="test_channel"                           \
+      --exec=cat                                         \
+      --workers=100
 ```
 
+Then, connect to your PostgreSQL database and execute the following command to issue a
+notification through the `tests_channel` channel:
 
+```sql
+postgres=# NOTIFY test_channel, 'hello from postgres';
+```
+
+The console will then have the following output:
+
+```
+[pg-dispatch] Listening to channel: "test_channel".
+[worker-1] Got payload: hello from postgres.
+[worker-1] Command succeded with status code 0.
+[cat-1] hello from postgres
+```
+
+#### Dispatching a command with arguments
+
+You can also use commands with arguments, just pass them inside the same string:.
+
+```sh
+$ ./target/release/pg-disptacher                         \
+      --db-uri='postgres://postgres@localhost/postgres'  \
+      --channel="test_channel"							 \
+	  --exec="sh some-script.sh"                         \
+      --workers=100
+```
+
+Where `some-script.sh` could be like:
+
+```sh
+#!/bin/sh
+
+PAYLOAD=$(cat) # read from stdin
+echo "The payload was: $PAYLOAD!"
+```
+
+Output *(after notification was issued)*:
+```
+[worker-1] Got payload: hello from postgres.
+[worker-1] Command succeded with status code 0.
+[sh-1] The payload was: hello from postgres!
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() {
     }
 
     println!(
-        "[pg-dispatch] Listening to \"{}\" channel.",
+        "[pg-dispatch] Listening to channel: \"{}\".",
         config.db_channel
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,11 +13,11 @@ use std::process::exit;
 
 
 fn main() {
-    // parse arguments and build dispatcher
+    // consume cli arguments
     let cli_matches = create_cli_app().get_matches();
     let config = Config::from_matches(&cli_matches);
 
-    // connect to the database
+    // connect to database
     let conn = match Connection::connect(config.db_url, TlsMode::None) {
         Ok(conn) => conn,
         Err(error) => {
@@ -39,10 +39,8 @@ fn main() {
     let notifications = conn.notifications();
     let mut iter = notifications.blocking_iter();
 
-    // instantiate dispatcher
     let dispatcher = Dispatcher::from_config(&config);
 
-    // main loop
     loop {
         match iter.next() {
             Ok(Some(notification)) => dispatcher.execute_command(notification.payload),

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -2,7 +2,7 @@ use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::ffi::OsString;
-use std::io::{Read, BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Write};
 
 /// For exchanging in the job channel
 enum Message {

--- a/src/thread_pool.rs
+++ b/src/thread_pool.rs
@@ -1,7 +1,8 @@
-use std::process::Command;
+use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex, mpsc};
 use std::thread;
 use std::ffi::OsString;
+use std::io::{Read, BufRead, BufReader, Write};
 
 /// For exchanging in the job channel
 enum Message {
@@ -84,28 +85,27 @@ impl Worker {
                 Message::Payload(payload) => {
                     println!("[worker-{}] Got payload: {}.", id, payload);
 
-                    // build & spawn command
+                    // spawn child command
                     // TODO: if a thread panics, does the threadpool replaces them?
-                    let output =
+                    let mut child =
                         Command::new(&program)
                             .args(program_arguments)
-                            .env("PG_DISPATCH_PAYLOAD", payload)
-                            .output()
+                            .stdin(Stdio::piped())
+                            .stdout(Stdio::piped())
+                            .stderr(Stdio::piped())
+                            .spawn()
                             .unwrap_or_else(|e| panic!("failed to execute process: {}\n", e));
 
-                    // collect stdout, stderr, status_code
-                    let stdout = String::from_utf8_lossy(&output.stdout);
-                    let stderr = String::from_utf8_lossy(&output.stderr);
-                    let exit_status = output.status;
+                    // pass payload data through child process stdin
+                    child
+                        .stdin
+                        .take()
+                        .unwrap()
+                        .write_all(payload.as_bytes())
+                        .expect("couldn't write to child process stdin");
 
-                    // propagate standard streams and exit status code
-                    for line in stderr.lines() {
-                        eprintln!("[{}-{}]! {}", program.to_str().unwrap(), id, line);
-                    }
-
-                    for line in stdout.lines() {
-                        println!("[{}-{}] {}", program.to_str().unwrap(), id, line);
-                    }
+                    // wait for child process to finish and propagate exit status code
+                    let exit_status = child.wait().unwrap();
                     match exit_status.success() {
                         true => {
                             println!(
@@ -123,6 +123,13 @@ impl Worker {
                                 exit_status.code().unwrap()
                             );
                         }
+                    }
+                    // propagate standard streams
+                    for line in BufReader::new(child.stderr.take().unwrap()).lines() {
+                        eprintln!("[{}-{}]! {}", program.to_str().unwrap(), id, line.unwrap())
+                    }
+                    for line in BufReader::new(child.stdout.take().unwrap()).lines() {
+                        println!("[{}-{}] {}", program.to_str().unwrap(), id, line.unwrap());
                     }
                 }
                 Message::Terminate => {


### PR DESCRIPTION
As the Unix philosophy suggests, **standard input** is the advisable interface for sending data to a program _(hence the name "standard")_ and it is where many existing programs expect to find their data source.

This PR:
- removes the `$PG_DISPATCH_PAYLOAD` enviroment variable from the child process.
- sends the notification's payload to the child process through its standard input.

Also:
- updates the README.txt usage examples