### PR TITLE
adds support to docker alpine

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,14 @@
+FROM alpine:3.7 as build-env
+RUN apk update && \
+      apk add rust cargo  openssl-dev libgcc
+
+WORKDIR /usr/app
+COPY . .
+
+RUN cargo build --release
+RUN cp -rf ./target/release/pg-dispatcher /usr/local/bin/
+
+FROM alpine:3.7
+RUN apk update && apk add openssl-dev libgcc
+
+COPY --from=build-env /usr/app/target/release/pg-dispatcher /usr/local/bin/


### PR DESCRIPTION
referred to https://github.com/common-group/pg-dispatcher/issues/7

> example

`docker run --net postgres -it comum/pg-dispatcher:alpine  /usr/local/bin/pg-dispatcher --db-uri='postgres://postgres@localhost/postgres
' --redis-uri='redis://localhost:6379' --channel='create_dns' --exec=cat --workers=10`